### PR TITLE
Updated codecov version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         if: ${{ matrix.python }} == '3.8'
         run: pytest --cov-report=xml --cov-append --cov=parsevasp
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1.0.7
+        uses: codecov/codecov-action@v1
         with:
           name: parsevasp
           fail_ci_if_error: true


### PR DESCRIPTION
In order to try to fix timeout issues as per https://github.com/codecov/codecov-action/issues/37 we here update to use latest v1 of `codecov`.