### PR TITLE
Fixed history for stream parser and added xml truncation function

### DIFF
--- a/parsevasp/stream.py
+++ b/parsevasp/stream.py
@@ -189,18 +189,21 @@ class Stream(BaseParser):
             A list of strings containing each line in the standard stream.
 
         """
+        # Copy the dictionary as we will use pop when we do not want history to
+        # remove items as we go
+        stream_triggers = dict(self._stream_triggers)
         for index, line in enumerate(stream):
             # Go though all entries in the stream triggers
-            for kind, triggers in self._stream_triggers.items():
+            for kind, triggers in stream_triggers.items():
                 # Not check all the triggers of the given kind
-                for trigger in triggers:
+                for index, trigger in enumerate(triggers):
                     trigger_record = trigger.check_line(line)
                     if trigger_record:
                         self._streams.append(trigger_record)
                         if not self._history:
-                            # Break on first stream detection if we do not want the
+                            # Pop stream trigger if we do not want the
                             # full history of streams (e.g. multiple stream occurrences recorded)
-                            break
+                            stream_triggers[kind].pop(index)
 
 
 class VaspStream:

--- a/parsevasp/vasprun.py
+++ b/parsevasp/vasprun.py
@@ -165,6 +165,11 @@ class Xml(BaseParser):
         # parse parse parse
         self._parse()
 
+    @property
+    def truncated(self):
+        """Return True of the xml parsed is truncated."""
+        return self._xml_recover
+        
     def _parse(self):
         """Perform the actual parsing
 
@@ -186,13 +191,13 @@ class Xml(BaseParser):
             return None
 
         # Do a quick check to see if the XML file is not truncated
-        xml_recover = self._check_xml()
-
-        if ((file_size < self._sizecutoff) or xml_recover) and \
+        self._xml_recover = self._check_xml()
+            
+        if ((file_size < self._sizecutoff) or self._xml_recover) and \
            not self._event:
             # run regular method (loads file into memory) and
             # enable recovery mode if necessary
-            self._parsew(xml_recover)
+            self._parsew(self._xml_recover)
         else:
             # event based, saves a bit of memory
             self._parsee()


### PR DESCRIPTION
Here we add a function that returns `True` if the xml is truncated. Previously the `lxml` parser entered recovery mode and the parser tried to parse quantities. This is okey, but sometimes this fails, depending on why and where the xml is truncated. A function was thus added which can be called to check if it has been truncated and then the caller can act accordingly. In addition we fixed the history of the stream parser. When this flag is set to `True` we also store similar streams if they occur multiple times. If `False` we only store the first occurrence.