### PR TITLE
Add parsing of timing data and NELM, NSW

### DIFF
--- a/parsevasp/vasprun.py
+++ b/parsevasp/vasprun.py
@@ -128,7 +128,9 @@ class Xml(BaseParser):
             'ispin': None,
             'nbands': None,
             'nelect': None,
-            'system': None
+            'system': None,
+            'nelm': None,
+            'nsw': None,
         }
         self._lattice = {
             'unitcell': None,
@@ -239,6 +241,8 @@ class Xml(BaseParser):
         self._parameters['nbands'] = self._fetch_nbandsw(vaspxml)
         self._parameters['nelect'] = self._fetch_nelectw(vaspxml)
         self._parameters['system'] = self._fetch_systemw(vaspxml)
+        self._parameters['nelm'] = self._fetch_nelmw(vaspxml)
+        self._parameters['nsw'] = self._fetch_nsww(vaspxml)
         self._lattice['species'] = self._fetch_speciesw(vaspxml)
         self._lattice['unitcell'], self._lattice['positions'], \
             self._data['forces'], self._data['stress'] = \
@@ -1129,6 +1133,67 @@ class Xml(BaseParser):
         sigma = self._convert_f(entry)
 
         return sigma
+
+    def _fetch_nelmw(self, xml):
+        """Fetch and set nelm using etree
+
+        Parameters
+        ----------
+        xml : object
+            An ElementTree object to be used for parsing.
+
+        Returns
+        -------
+        nelm : float
+            If NELM is found it is returned.
+
+        Notes
+        -----
+        Maximum number of eletronic steps. This is needed for checking if the eletronic
+        structure is converged. 
+
+        """
+
+        entry = self._find(
+            xml, './/parameters/separator[@name="electronic"]/'
+            'separator[@name="electronic convergence"]/'
+            'i[@name="NELM"]')
+
+        if entry is None:
+            return None
+
+        nelm = self._convert_i(entry)
+
+        return nelm
+
+    def _fetch_nsww(self, xml):
+        """Fetch and set nsw using etree
+
+        Parameters
+        ----------
+        xml : object
+            An ElementTree object to be used for parsing.
+
+        Returns
+        -------
+        nsw : int
+            If NSW is found it is returned.
+
+        Notes
+        -----
+        Maximum number of eletronic steps. This is needed for checking ionic convergence. 
+        """
+
+        entry = self._find(
+            xml, './/parameters/separator[@name="ionic"]/'
+            'i[@name="NSW"]')
+
+        if entry is None:
+            return None
+
+        nsw = self._convert_i(entry)
+
+        return nsw
 
     def _fetch_ispinw(self, xml):
         """Fetch and set ispin using etree

--- a/parsevasp/vasprun.py
+++ b/parsevasp/vasprun.py
@@ -418,6 +418,17 @@ class Xml(BaseParser):
                         self._parameters['system'] = element.text
                 except KeyError:
                     pass
+                try:
+                    if event == 'start' and element.attrib['name'] == 'NELM' \
+                        and element.getparent().attrib['name'] == 'electronic convergence':
+                        self._parameters['nelm'] = self._convert_i(element)
+                except KeyError:
+                    pass
+                try:
+                    if event == 'start' and element.attrib['name'] == 'NSW':
+                        self._parameters['nsw'] = self._convert_i(element)
+                except KeyError:
+                    pass
 
             if extract_calculation:
                 attribute = calc

--- a/tests/test_outcar.py
+++ b/tests/test_outcar.py
@@ -350,3 +350,23 @@ def test_outcar_magnetization_single(outcar_parser_magnetization_single):
     _mag = np.asarray(list(magnetization['full_cell']))
     _test = np.asarray(list(test['full_cell']))
     np.testing.assert_allclose(_mag, _test)
+
+
+def test_outcar_elastic_file_object(outcar_parser_file_objects):
+    """Check if outcar_parser returns correct timing information.
+    """
+
+    timings = outcar_parser_file_objects.get_run_stats()
+    assert timings['total_cpu_time_used'] == 89.795
+    assert timings['user_time'] == 60.247
+    assert timings['elapsed_time'] == 90.990
+    assert timings['system_time'] == 29.549
+    assert timings['maximum_memory_used'] == 81612.0
+    assert timings['average_memory_used'] == 0.0
+
+    assert timings['mem_usage_base'] == 30000.0
+    assert timings['mem_usage_nonl-proj'] == 2198.0
+    assert timings['mem_usage_fftplans'] == 304.0
+    assert timings['mem_usage_grid'] == 903.0
+    assert timings['mem_usage_one-center'] == 6.0
+    assert timings['mem_usage_wavefun'] == 559.0

--- a/tests/test_xml_event.py
+++ b/tests/test_xml_event.py
@@ -79,7 +79,7 @@ def test_xml_stress(xml_parser):
 
 
 @pytest.mark.parametrize('xml_parser', ['basic.xml'], indirect=True)
-def test_xml_hessian(xml_parser):
+def test_xml_hessian_basic(xml_parser):
     """Check hessian matrix.
 
     """
@@ -88,7 +88,7 @@ def test_xml_hessian(xml_parser):
 
 
 @pytest.mark.parametrize('xml_parser', ['basic.xml'], indirect=True)
-def test_xml_dynmat(xml_parser):
+def test_xml_dynmat_basic(xml_parser):
     """Check the dynamical metrix.
 
     """
@@ -97,7 +97,7 @@ def test_xml_dynmat(xml_parser):
 
 
 @pytest.mark.parametrize('xml_parser', ['basic.xml'], indirect=True)
-def test_xml_dielectrics(xml_parser):
+def test_xml_dielectrics_basic(xml_parser):
     """Check the dielectric functions.
 
     """
@@ -106,7 +106,7 @@ def test_xml_dielectrics(xml_parser):
 
 
 @pytest.mark.parametrize('xml_parser', ['basic.xml'], indirect=True)
-def test_xml_born(xml_parser):
+def test_xml_born_basic(xml_parser):
     """Check the born effective masses.
 
     """
@@ -545,6 +545,16 @@ def test_xml_eivenalues_partial(xml_parser):
     np.testing.assert_allclose(projected['total'][0, 0, 2:5, 1], test)
     test = np.array([0.025, 0.0001, 0.0243])
     np.testing.assert_allclose(projected['total'][4, 10, 2:5, 1], test)
+
+
+@pytest.mark.parametrize('xml_parser', ['basicpartial.xml'], indirect=True)
+def test_xml_parameters_partial(xml_parser):
+    """Check the parsing of parameters"""
+    parameters = xml_parser.get_parameters()
+    assert parameters['nelm'] == 60
+    assert parameters['nsw'] == 0
+    assert parameters['nbands'] == 21
+    assert parameters['ispin'] == 1
 
 
 @pytest.mark.parametrize('xml_parser', ['dielectrics.xml'], indirect=True)

--- a/tests/test_xml_regular.py
+++ b/tests/test_xml_regular.py
@@ -785,6 +785,16 @@ def test_xml_ionic(xml_parser):
     np.testing.assert_allclose(stress[10][1], testing)
 
 
+def test_xml_parameters(xml_parser):
+    """Test if parameters can be parsed"""
+    xml_data = xml_parser(filename='basicrelax.xml')
+    parameters = xml_data.get_parameters()
+    parameters['nelm'] = 60
+    parameters['nws'] = 80
+    parameters['nbands'] = 21
+    parameters['ispin'] = 1
+
+
 def test_xml_overflow(xml_parser):
     """Check that if we detect overflow (typically **** in place of number) we do a SystemExit.
 


### PR DESCRIPTION
Timing data can be very useful for benchmarks, convergence
testings.
The extraction of NELM/NSW is needed for determining whether
the electronic/ionic convergence is reached since vasp always
pretends they are converged once the maximum step is reached.
