### PR TITLE
Fix truncate detection

### DIFF
--- a/parsevasp/vasprun.py
+++ b/parsevasp/vasprun.py
@@ -3328,7 +3328,7 @@ class Xml(BaseParser):
                 mapping = mmap.mmap(source.fileno(), 0, prot=mmap.PROT_READ)
 
         last_line = mapping[mapping.rfind(b'\n', 0, -1) + 1:]
-        if last_line == b'</modeling>':
+        if b'</modeling>' in last_line:
             return False
         else:
             return True

--- a/parsevasp/vasprun.py
+++ b/parsevasp/vasprun.py
@@ -3328,7 +3328,7 @@ class Xml(BaseParser):
                 mapping = mmap.mmap(source.fileno(), 0, prot=mmap.PROT_READ)
 
         last_line = mapping[mapping.rfind(b'\n', 0, -1) + 1:]
-        if last_line == '</modeling>\n':
+        if last_line == b'</modeling>':
             return False
         else:
             return True

--- a/tests/test_xml_regular.py
+++ b/tests/test_xml_regular.py
@@ -24,6 +24,7 @@ def xml_parser(request, tmpdir_factory):
         tmpfile = str(tmpdir_factory.mktemp('data').join('basic_trunc.xml'))
         xml_truncate(request.param, xmlfile, tmpfile)
         xml = Xml(tmpfile, event=False)
+        xml.truncate_expected = True if request.param == 1 else False
         return xml
 
     return make_xml_parser
@@ -60,6 +61,14 @@ def xml_truncate(index, original, tmp):
         xmlfile.write(str(truncated_content))
 
     return
+
+
+def test_xml_truncate_detection(xml_parser):
+    """Test truncation detection
+    
+    """
+    parser = xml_parser()
+    assert parser.truncated == parser.truncate_expected
 
 
 def test_xml_exist(xml_parser):


### PR DESCRIPTION
The `laset_line` of the XML file returned is a byte object and previously it was compared to a string so the function always returns `True` and the XML is considered as truncated. 

In practice, sometimes it is `b'</modeling>\n'` some times it is `b'</modeling>', both cases are supported now. ~~Not sure why!~~ might be related to whether a file object or file path was used?

A test is added to make sure the truncation detection works as expected. 