### PR TITLE
Added error that can happen if you only set NSW

### DIFF
--- a/parsevasp/stream.yml
+++ b/parsevasp/stream.yml
@@ -163,3 +163,10 @@ sgrcon:
   recover: false
   regex: internal error in subroutine SGRCON
   suggestion: ''
+no_potim:
+  kind: ERROR
+  location: STDOUT
+  message: NSW specified, but no POTIM or IBRION set
+  recover: false
+  regex: 'Fatal error! IBRION=0, but no entry for POTIM on file INCAR. MUST be specified!!'
+  suggestion: ''


### PR DESCRIPTION
Here we add an error that occur if you e.g. set `NSW` but forget to set `IBRION` or `POTIM`.