### PR TITLE
Fix timiming/memory lines being be N/A in VASP

### DIFF
--- a/parsevasp/outcar.py
+++ b/parsevasp/outcar.py
@@ -365,10 +365,18 @@ class Outcar(BaseParser):
             if time_mem_pattern.search(line):
                 tokens = line.strip().split(":")
                 item_name = "_".join(tmp.lower() for tmp in tokens[0].strip().split()[:-1])
-                info[item_name] = float(tokens[1].strip())
+                # The entry can be empty (VASP6)
+                try:
+                    info[item_name] = float(tokens[1].strip())
+                except ValueError:
+                    info[item_name] = None
 
             elif mem_pattern.search(line):
                 tokens = re.split(r'[: ]+', line.strip())
-                info['mem_usage_' + tokens[0]] = float(tokens[-2])
+                try:
+                    info['mem_usage_' + tokens[0]] = float(tokens[-2])
+                except ValueError:
+                    info['mem_usage_' + tokens[0]] = None
+            
             
         return info


### PR DESCRIPTION
In VASP6 the output can be like:

>
                  Total CPU time used (sec):       68.875
                            User time (sec):       67.104
                          System time (sec):        1.771
                         Elapsed time (sec):       72.427

                   Maximum memory used (kb):      188368.
                   Average memory used (kb):          N/A

                          Minor page faults:       102806
                          Major page faults:            1
                 Voluntary context switches:         4522

Hence, we have to handle the case where the values are not numbers but `N/A`. If that is the case, the relevant values are set to `None`. 