### PR TITLE
Fixed splitting of comments in DOSCAR parser

### DIFF
--- a/parsevasp/doscar.py
+++ b/parsevasp/doscar.py
@@ -152,7 +152,7 @@ class Doscar(BaseParser):
         coord_type = utils.line_to_type(doscar[3])
 
         # Name of system
-        name = utils.line_to_type(doscar[4])
+        system = utils.line_to_type(doscar[4], no_split=True)
 
         # Energy min, energy max, number of points between, fermi level, weight
         line_2 = utils.line_to_type(doscar[5], float)
@@ -209,7 +209,7 @@ class Doscar(BaseParser):
         metadata['n_ions'] = num_ions
         metadata['n_atoms'] = num_atoms
         metadata['cartesian'] = coord_type.startswith(('c', 'C'))
-        metadata['name'] = name
+        metadata['name'] = system
         metadata['emax'] = emax
         metadata['emin'] = emin
         metadata['n_dos'] = ndos

--- a/parsevasp/utils.py
+++ b/parsevasp/utils.py
@@ -391,7 +391,7 @@ def match_integer_param(inputs, key, string):
     if match:
         inputs[key.lower()] = int(match.group(1))
 
-def line_to_type(fobject_or_string, d_type=str):
+def line_to_type(fobject_or_string, d_type=str, no_split=False):
     """
     Grab a line from a file like object or string and convert it to d_type (default: str).
     
@@ -401,6 +401,8 @@ def line_to_type(fobject_or_string, d_type=str):
         A file like object or a string containing something that is to be converted to a specified type
     dtype : object
         The dtype one want to convert to. The standard Python dtypes are supported.
+    no_splot : bool
+        If True do not split a string. Useful for comments etc. We still strip.
     
     """
     if isinstance(fobject_or_string, str):
@@ -408,7 +410,10 @@ def line_to_type(fobject_or_string, d_type=str):
     else:
         line = fobject_or_string.readline()
     # Previously this was map instead of list comprehension
-    result = [d_type(item) for item in line.split()]
+    if not no_split:
+        result = [d_type(item) for item in line.split()]
+    else:
+        result = line.strip()
     if len(result) == 1:
         return result[0]
     return result


### PR DESCRIPTION
Fixed an issue with the comment of the system being overridden by the iterations in the parser. Also removed splitting of the string used for the comment.