### PR TITLE
Fixed split of system for EIGENVAL and tests

### DIFF
--- a/parsevasp/eigenval.py
+++ b/parsevasp/eigenval.py
@@ -92,8 +92,8 @@ class Eigenval(BaseParser):
         line_2 = utils.line_to_type(eigenval[2], float)
         coord_type = utils.line_to_type(eigenval[3])
 
-        # Read name
-        name = utils.line_to_type(eigenval[4])
+        # Read system
+        system = utils.line_to_type(eigenval[4], no_split=True)
 
         # Read number of kpoints and bands
         param_0, num_kp, num_bands = utils.line_to_type(eigenval[5], int)
@@ -132,7 +132,7 @@ class Eigenval(BaseParser):
         metadata['p00'] = p00
         metadata['nspin'] = num_spins
         metadata['cartesian'] = coord_type.startswith(('c', 'C'))
-        metadata['name'] = name
+        metadata['name'] = system
         metadata['some_num'] = param_0
         metadata['n_bands'] = num_bands
         metadata['n_kp'] = num_kp

--- a/tests/test_doscar.py
+++ b/tests/test_doscar.py
@@ -4,7 +4,7 @@ import numpy as np
 from parsevasp.doscar import Doscar
 
 
-total_dos = np.array([(-3.44, -1.10400000e-43, -2.09900000e-43),
+compare_total_dos = np.array([(-3.44, -1.10400000e-43, -2.09900000e-43),
                       (-1.539, 1.40000000e-01, 2.66100000e-01),
                       (0.362, -3.62400000e-73, 2.00000000e+00),
                       (2.264, -1.33800000e-05, 2.00000000e+00),
@@ -15,7 +15,7 @@ total_dos = np.array([(-3.44, -1.10400000e-43, -2.09900000e-43),
                       (11.769, 2.90100000e+00, 1.95200000e+01),
                       (13.67, 0.00000000e+00, 2.00000000e+01)],
                      dtype=[('energy', '<f8'), ('total', '<f8'), ('integrated', '<f8')])  # yapf: disable
-partial_dos = np.array([[(-3.44 , -6.543e-45, -3.040e-46, -3.040e-46, -3.040e-46, 0., 0., 0., 0., 0.),
+compare_partial_dos = np.array([[(-3.44 , -6.543e-45, -3.040e-46, -3.040e-46, -3.040e-46, 0., 0., 0., 0., 0.),
                          (-1.539,  8.295e-03,  3.853e-04,  3.853e-04,  3.853e-04, 0., 0., 0., 0., 0.),
                          ( 0.362, -1.336e-74, -3.400e-75, -3.400e-75, -3.400e-75, 0., 0., 0., 0., 0.),
                          ( 2.264, -4.932e-07, -1.255e-07, -1.255e-07, -1.255e-07, 0., 0., 0., 0., 0.),
@@ -56,7 +56,7 @@ partial_dos = np.array([[(-3.44 , -6.543e-45, -3.040e-46, -3.040e-46, -3.040e-46
                          (11.769,  5.486e-02,  3.117e-02,  3.938e-02,  3.827e-02, 0., 0., 0., 0., 0.),
                          (13.67 ,  0.000e+00,  0.000e+00,  0.000e+00,  0.000e+00, 0., 0., 0., 0., 0.)]],
                        dtype=[('energy', '<f8'), ('s', '<f8'), ('py', '<f8'), ('px', '<f8'), ('pz', '<f8'), ('dxy', '<f8'), ('dyz', '<f8'), ('dz2', '<f8'), ('dxz', '<f8'), ('dx2-y2', '<f8')])
-metadata = {'n_ions': 4, 'n_atoms': 4, 'cartesian': True, 'name': 'unknown system', 'emax': 13.67039808, 'emin': -3.43982524, 'n_dos': 10, 'efermi': 7.29482275, 'weight': 1.0}
+compare_metadata = {'n_ions': 4, 'n_atoms': 4, 'cartesian': True, 'name': 'unknown system', 'emax': 13.67039808, 'emin': -3.43982524, 'n_dos': 10, 'efermi': 7.29482275, 'weight': 1.0}
 
 @pytest.fixture
 def doscar_parser(request):
@@ -96,7 +96,7 @@ def test_doscar(doscar_parser):
     """Test that the content returned by the DOSCAR parser returns total density of states."""
     dos = doscar_parser.get_dos()
     for item in dos.dtype.names:
-        assert np.allclose(dos[item], total_dos[item])
+        assert np.allclose(dos[item], compare_total_dos[item])
 
 def test_doscar_file_objcet(doscar_parser_file_object):
     """
@@ -105,25 +105,25 @@ def test_doscar_file_objcet(doscar_parser_file_object):
     """
     dos = doscar_parser_file_object.get_dos()
     for item in dos.dtype.names:
-        assert np.allclose(dos[item], total_dos[item])
+        assert np.allclose(dos[item], compare_total_dos[item])
 
 @pytest.mark.parametrize('doscar_parser', ['DOSCAR.nopdos'], indirect=['doscar_parser'])
 def test_doscar_nopdos(doscar_parser):
     """Test that the content returned by the DOSCAR parser returns total density of states."""
     dos = doscar_parser.get_dos()
     for item in dos.dtype.names:
-        assert np.allclose(dos[item], total_dos[item])
+        assert np.allclose(dos[item], compare_total_dos[item])
     assert not doscar_parser.get_pdos()
         
 def test_doscar_partial(doscar_parser):
     """Test that the content returned by the DOSCAR parser returns the partial density of states."""
     pdos = doscar_parser.get_pdos()
-    for item in partial_dos.dtype.names:
-        assert np.allclose(pdos[item], partial_dos[item])
+    for item in compare_partial_dos.dtype.names:
+        assert np.allclose(pdos[item], compare_partial_dos[item])
 
 def test_doscar_header(doscar_parser):
     """Test that the header of the DOSCAR parser returns correct keys and values."""
-    assert metadata == doscar_parser.get_metadata()
+    assert compare_metadata == doscar_parser.get_metadata()
 
 @pytest.mark.parametrize('doscar_parser', ['DOSCAR.spin'], indirect=['doscar_parser'])
 def test_doscar_spin(doscar_parser):

--- a/tests/test_eigenval.py
+++ b/tests/test_eigenval.py
@@ -3,6 +3,10 @@ import pytest
 import numpy as np
 from parsevasp.eigenval import Eigenval
 
+compare_bands = np.array([[[-1.439825, 2.964373, 2.964373, 2.964373, 7.254542, 7.254542, 7.254542, 11.451811, 11.670398, 11.670398]]])
+compare_kpoints = np.array([[0.25, 0.25, 0.25, 1.0]])
+compare_metadata = {0: [4, 4, 1, 1], 1: [16.48482, 4.04e-10, 4.04e-10, 4.04e-10, 1e-16], 2: 0.0001, 'n_ions': 4, 'n_atoms': 4, 'p00': 1, 'nspin': 1, 'cartesian': True, 'name': 'unknown system', 'some_num': 12, 'n_bands': 10, 'n_kp': 1}
+
 @pytest.fixture
 def eigenval_parser(request):
     """Load EIGENVAL file.
@@ -38,23 +42,10 @@ def eigenval_parser_file_object(request):
     return eigenval
 
 def test_eigenval(eigenval_parser):
+    """Test that the content returned by the EIGENVAL parser returns correct bands, kpoints and metadata."""
     bands = eigenval_parser.get_bands()
     kpoints = eigenval_parser.get_kpoints()
     metadata = eigenval_parser.get_metadata()
-    compare_bands = np.array([[[-1.439825, 2.964373, 2.964373, 2.964373, 7.254542, 7.254542, 7.254542, 11.451811, 11.670398, 11.670398]]])
-    compare_kpoints = np.array([[0.25, 0.25, 0.25, 1.0]])
-    compare_metadata = {0: [4, 4, 1, 1], 1: [16.48482, 4.04e-10, 4.04e-10, 4.04e-10, 1e-16], 2: 0.0001, 'n_ions': 4, 'n_atoms': 4, 'p00': 1, 'nspin': 1, 'cartesian': True, 'name': ['unknown', 'system'], 'some_num': 12, 'n_bands': 10, 'n_kp': 1}
-    assert np.allclose(bands, compare_bands)
-    assert np.allclose(kpoints, compare_kpoints)
-    assert metadata == compare_metadata
-
-def test_eigenval_file_object(eigenval_parser_file_object):
-    bands = eigenval_parser_file_object.get_bands()
-    kpoints = eigenval_parser_file_object.get_kpoints()
-    metadata = eigenval_parser_file_object.get_metadata()
-    compare_bands = np.array([[[-1.439825, 2.964373, 2.964373, 2.964373, 7.254542, 7.254542, 7.254542, 11.451811, 11.670398, 11.670398]]])
-    compare_kpoints = np.array([[0.25, 0.25, 0.25, 1.0]])
-    compare_metadata = {0: [4, 4, 1, 1], 1: [16.48482, 4.04e-10, 4.04e-10, 4.04e-10, 1e-16], 2: 0.0001, 'n_ions': 4, 'n_atoms': 4, 'p00': 1, 'nspin': 1, 'cartesian': True, 'name': ['unknown', 'system'], 'some_num': 12, 'n_bands': 10, 'n_kp': 1}
     assert np.allclose(bands, compare_bands)
     assert np.allclose(kpoints, compare_kpoints)
     assert metadata == compare_metadata


### PR DESCRIPTION
Here we remove the split of the string that governs the system comment. Also cleaned tests.