### PR TITLE
Fixed tetra is None if not found

### DIFF
--- a/parsevasp/kpoints.py
+++ b/parsevasp/kpoints.py
@@ -209,10 +209,10 @@ class Kpoints(BaseParser):
                     weight = float(kentry[3])
                 points.append(Kpoint(point, weight, direct=direct))
             loopmax = num_kpoints + loopmax
-            tetra = []
             if len(kpoints) > loopmax:
                 if kpoints[loopmax].strip()[0].lower() == 't':
                     # Tetrahedron info present
+                    tetra = []
                     loopmax = loopmax + 1
                     if len(kpoints) > loopmax:
                         first_line = kpoints[loopmax].split()


### PR DESCRIPTION
Here we fix a bug which caused the `tetra` key to be an empty list if tetrahedron information was not found in the `KPOINTS`. This later cased the `write` to fail for instance.