### PR TITLE
Add error message for incomplete OUTCAR

### DIFF
--- a/parsevasp/outcar.py
+++ b/parsevasp/outcar.py
@@ -9,6 +9,12 @@ from parsevasp.base import BaseParser
 
 
 class Outcar(BaseParser):
+    ERROR_NO_ITERATIONS = 600
+    BaseParser.ERROR_MESSAGES.update({
+        ERROR_NO_ITERATIONS: 'A crash detected before the first SCF step.'
+    })
+    ERROR_MESSAGES = BaseParser.ERROR_MESSAGES
+
     def __init__(self,
                  file_path=None,
                  file_handler=None,
@@ -126,6 +132,7 @@ class Outcar(BaseParser):
         s_orb = {0: 's', 1: 'p', 2: 'd', 3: 'f'}
         params = {'ibrion': -1}
         finished = False
+        iter_counter = None
         nelec_steps = {}
 
         for index, line in enumerate(outcar):
@@ -249,6 +256,11 @@ class Outcar(BaseParser):
                 self._data['magnetization']['full_cell'] = [
                     float(_val) for _val in outcar[index].strip().split()[5:]
                 ]
+
+        # Check if SCF iterations are contained in the file
+        if iter_counter is None:
+            self._logger.error(self.ERROR_MESSAGES[self.ERROR_NO_ITERATIONS])
+            sys.exit(self.ERROR_NO_ITERATIONS)
 
         # Work out if the ionic relaxation and electronic steps are to be considered converged
         run_status = self._data['run_status']

--- a/tests/OUTCAR.crashed
+++ b/tests/OUTCAR.crashed
@@ -1,0 +1,232 @@
+ vasp.5.4.4.18Apr17-6-g9f103f2a35 (build Jun 11 2017 21:30:58) complex          
+  
+ executed on             LinuxIFC date 2021.12.05  12:01:41
+ running on   16 total cores
+ distrk:  each k-point on   16 cores,    1 groups
+ distr:  one band on NCORES_PER_BAND=   1 cores,   16 groups
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ INCAR:
+ POTCAR:    PAW_PBE Si 05Jan2001                  
+
+ ----------------------------------------------------------------------------- 
+|                                                                             |
+|           W    W    AA    RRRRR   N    N  II  N    N   GGGG   !!!           |
+|           W    W   A  A   R    R  NN   N  II  NN   N  G    G  !!!           |
+|           W    W  A    A  R    R  N N  N  II  N N  N  G       !!!           |
+|           W WW W  AAAAAA  RRRRR   N  N N  II  N  N N  G  GGG   !            |
+|           WW  WW  A    A  R   R   N   NN  II  N   NN  G    G                |
+|           W    W  A    A  R    R  N    N  II  N    N   GGGG   !!!           |
+|                                                                             |
+|      For optimal performance we recommend to set                            |
+|        NCORE= 4 - approx SQRT( number of cores)                             |
+|      NCORE specifies how many cores store one orbital (NPAR=cpu/NCORE).     |
+|      This setting can  greatly improve the performance of VASP for DFT.     |
+|      The default,   NCORE=1            might be grossly inefficient         |
+|      on modern multi-core architectures or massively parallel machines.     |
+|      Do your own testing !!!!                                               |
+|      Unfortunately you need to use the default for GW and RPA calculations. |
+|      (for HF NCORE is supported but not extensively tested yet)             |
+|                                                                             |
+ ----------------------------------------------------------------------------- 
+
+ POTCAR:    PAW_PBE Si 05Jan2001                  
+   VRHFIN =Si: s2p2                                                             
+   LEXCH  = PE                                                                  
+   EATOM  =   103.0669 eV,    7.5752 Ry                                         
+                                                                                
+   TITEL  = PAW_PBE Si 05Jan2001                                                
+   LULTRA =        F    use ultrasoft PP ?                                      
+   IUNSCR =        1    unscreen: 0-lin 1-nonlin 2-no                           
+   RPACOR =    1.500    partial core radius                                     
+   POMASS =   28.085; ZVAL   =    4.000    mass and valenz                      
+   RCORE  =    1.900    outmost cutoff radius                                   
+   RWIGS  =    2.480; RWIGS  =    1.312    wigner-seitz radius (au A)           
+   ENMAX  =  245.345; ENMIN  =  184.009 eV                                      
+   ICORE  =        2    local potential                                         
+   LCOR   =        T    correct aug charges                                     
+   LPAW   =        T    paw PP                                                  
+   EAUG   =  322.069                                                            
+   DEXC   =    0.000                                                            
+   RMAX   =    1.950    core radius for proj-oper                               
+   RAUG   =    1.300    factor for augmentation sphere                          
+   RDEP   =    1.993    radius for radial grids                                 
+   RDEPT  =    1.837    core radius for aug-charge                              
+                                                                                
+   Atomic configuration                                                         
+    6 entries                                                                   
+     n  l   j            E        occ.                                          
+     1  0  0.50     -1785.8828   2.0000                                         
+     2  0  0.50      -139.4969   2.0000                                         
+     2  1  1.50       -95.5546   6.0000                                         
+     3  0  0.50       -10.8127   2.0000                                         
+     3  1  0.50        -4.0811   2.0000                                         
+     3  2  1.50        -4.0817   0.0000                                         
+   Description                                                                  
+     l       E           TYP  RCUT    TYP  RCUT                                 
+     0    -10.8127223     23  1.900                                             
+     0     -7.6451159     23  1.900                                             
+     1     -4.0811372     23  1.900                                             
+     1      2.4879257     23  1.900                                             
+     2     -4.0817478      7  1.900                                             
+  local pseudopotential read in
+  partial core-charges read in
+  partial kinetic energy density read in
+  atomic valenz-charges read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           0  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+  non local Contribution for L=           1  read in
+    real space projection operators read in
+    PAW grid and wavefunctions read in
+ 
+   number of l-projection  operators is LMAX  =           4
+   number of lm-projection operators is LMMAX =           8
+ 
+  PAW_PBE Si 05Jan2001                  :
+ energy of atom  1       EATOM= -103.0669
+ kinetic energy error for atom=    0.0107 (will be added to EATOM!!)
+ 
+ 
+ POSCAR: # Compound: Si2. Old comment: Si2       
+  positions in direct lattice
+  No initial velocities read in
+ exchange correlation table for  LEXCH =        8
+   RHO(1)=    0.500       N(1)  =     2000
+   RHO(2)=  100.500       N(2)  =     4000
+ 
+
+
+--------------------------------------------------------------------------------------------------------
+
+
+ ion  position               nearest neighbor table
+   1  0.875  0.875  0.875-   2 2.35   2 2.35   2 2.35   2 2.35
+   2  0.125  0.125  0.125-   1 2.35   1 2.35   1 2.35   1 2.35
+ 
+  LATTYP: Found a face centered cubic cell.
+ ALAT       =     5.4310000000
+  
+  Lattice vectors:
+  
+ A1 = (   2.7155000000,   0.0000000000,   2.7155000000)
+ A2 = (   2.7155000000,   2.7155000000,   0.0000000000)
+ A3 = (   0.0000000000,   2.7155000000,   2.7155000000)
+
+
+Analysis of symmetry for initial positions (statically):
+=====================================================================
+ Subroutine PRICEL returns:
+ Original cell was already a primitive cell.
+ 
+
+ Routine SETGRP: Setting up the symmetry group for a 
+ face centered cubic supercell.
+
+
+ Subroutine GETGRP returns: Found 48 space group operations
+ (whereof 12 operations were pure point group operations)
+ out of a pool of 48 trial point group operations.
+
+
+The static configuration has the point symmetry D_3d.
+ The point group associated with its full space group is O_h .
+
+
+Analysis of symmetry for dynamics (positions and initial velocities):
+=====================================================================
+ Subroutine PRICEL returns:
+ Original cell was already a primitive cell.
+ 
+
+ Routine SETGRP: Setting up the symmetry group for a 
+ face centered cubic supercell.
+
+
+ Subroutine GETGRP returns: Found 48 space group operations
+ (whereof 12 operations were pure point group operations)
+ out of a pool of 48 trial point group operations.
+
+
+The dynamic configuration has the point symmetry D_3d.
+ The point group associated with its full space group is O_h .
+
+
+ Subroutine INISYM returns: Found 48 space group operations
+ (whereof 12 operations are pure point group operations),
+ and found     1 'primitive' translations
+
+ 
+ 
+ KPOINTS: # No comment                            
+  k-points in reciprocal lattice
+Space group operators:
+ irot       det(A)        alpha          n_x          n_y          n_z        tau_x        tau_y        tau_z
+    1     1.000000     0.000001     1.000000     0.000000     0.000000     0.000000     0.000000     0.000000
+    2    -1.000000     0.000001     1.000000     0.000000     0.000000     0.000000     0.000000     0.000000
+    3     1.000000   120.000000    -0.577350    -0.577350    -0.577350     0.000000     0.000000     0.000000
+    4    -1.000000   120.000000    -0.577350    -0.577350    -0.577350     0.000000     0.000000     0.000000
+    5     1.000000   120.000000     0.577350     0.577350     0.577350     0.000000     0.000000     0.000000
+    6    -1.000000   120.000000     0.577350     0.577350     0.577350     0.000000     0.000000     0.000000
+    7     1.000000   180.000000     0.707107     0.000000    -0.707107     0.000000     0.000000     0.000000
+    8    -1.000000   180.000000     0.707107     0.000000    -0.707107     0.000000     0.000000     0.000000
+    9     1.000000   180.000000     0.000000    -0.707107     0.707107     0.000000     0.000000     0.000000
+   10    -1.000000   180.000000     0.000000    -0.707107     0.707107     0.000000     0.000000     0.000000
+   11     1.000000   180.000000     0.707107    -0.707107     0.000000     0.000000     0.000000     0.000000
+   12    -1.000000   180.000000     0.707107    -0.707107     0.000000     0.000000     0.000000     0.000000
+   13     1.000000    90.000000    -1.000000     0.000000     0.000000     0.500000     0.000000     0.000000
+   14    -1.000000    90.000000    -1.000000     0.000000     0.000000     0.500000     0.000000     0.000000
+   15     1.000000   180.000000     0.707107     0.000000     0.707107     0.500000     0.000000     0.000000
+   16    -1.000000   180.000000     0.707107     0.000000     0.707107     0.500000     0.000000     0.000000
+   17     1.000000    90.000000     0.000000     0.000000     1.000000     0.500000     0.000000     0.000000
+   18    -1.000000    90.000000     0.000000     0.000000     1.000000     0.500000     0.000000     0.000000
+   19     1.000000   180.000000     1.000000     0.000000     0.000000     0.000000     0.000000     0.500000
+   20    -1.000000   180.000000     1.000000     0.000000     0.000000     0.000000     0.000000     0.500000
+   21     1.000000   120.000000     0.577350    -0.577350     0.577350     0.000000     0.000000     0.500000
+   22    -1.000000   120.000000     0.577350    -0.577350     0.577350     0.000000     0.000000     0.500000
+   23     1.000000   120.000000    -0.577350    -0.577350     0.577350     0.000000     0.000000     0.500000
+   24    -1.000000   120.000000    -0.577350    -0.577350     0.577350     0.000000     0.000000     0.500000
+   25     1.000000    90.000000     1.000000     0.000000     0.000000     0.000000     0.500000     0.000000
+   26    -1.000000    90.000000     1.000000     0.000000     0.000000     0.000000     0.500000     0.000000
+   27     1.000000    90.000000     0.000000    -1.000000     0.000000     0.000000     0.500000     0.000000
+   28    -1.000000    90.000000     0.000000    -1.000000     0.000000     0.000000     0.500000     0.000000
+   29     1.000000   180.000000     0.707107     0.707107     0.000000     0.000000     0.500000     0.000000
+   30    -1.000000   180.000000     0.707107     0.707107     0.000000     0.000000     0.500000     0.000000
+   31     1.000000   120.000000     0.577350     0.577350    -0.577350     0.500000     0.000000     0.000000
+   32    -1.000000   120.000000     0.577350     0.577350    -0.577350     0.500000     0.000000     0.000000
+   33     1.000000   120.000000     0.577350    -0.577350    -0.577350     0.500000     0.000000     0.000000
+   34    -1.000000   120.000000     0.577350    -0.577350    -0.577350     0.500000     0.000000     0.000000
+   35     1.000000   180.000000     0.000000     1.000000     0.000000     0.500000     0.000000     0.000000
+   36    -1.000000   180.000000     0.000000     1.000000     0.000000     0.500000     0.000000     0.000000
+   37     1.000000    90.000000     0.000000     0.000000    -1.000000     0.000000     0.000000     0.500000
+   38    -1.000000    90.000000     0.000000     0.000000    -1.000000     0.000000     0.000000     0.500000
+   39     1.000000   180.000000     0.000000     0.707107     0.707107     0.000000     0.000000     0.500000
+   40    -1.000000   180.000000     0.000000     0.707107     0.707107     0.000000     0.000000     0.500000
+   41     1.000000    90.000000     0.000000     1.000000     0.000000     0.000000     0.000000     0.500000
+   42    -1.000000    90.000000     0.000000     1.000000     0.000000     0.000000     0.000000     0.500000
+   43     1.000000   120.000000    -0.577350     0.577350    -0.577350     0.000000     0.500000     0.000000
+   44    -1.000000   120.000000    -0.577350     0.577350    -0.577350     0.000000     0.500000     0.000000
+   45     1.000000   180.000000     0.000000     0.000000     1.000000     0.000000     0.500000     0.000000
+   46    -1.000000   180.000000     0.000000     0.000000     1.000000     0.000000     0.500000     0.000000
+   47     1.000000   120.000000    -0.577350     0.577350     0.577350     0.000000     0.500000     0.000000
+   48    -1.000000   120.000000    -0.577350     0.577350     0.577350     0.000000     0.500000     0.000000
+
+ ----------------------------------------------------------------------------- 
+|                                                                             |
+|     EEEEEEE  RRRRRR   RRRRRR   OOOOOOO  RRRRRR      ###     ###     ###     |
+|     E        R     R  R     R  O     O  R     R     ###     ###     ###     |
+|     E        R     R  R     R  O     O  R     R     ###     ###     ###     |
+|     EEEEE    RRRRRR   RRRRRR   O     O  RRRRRR       #       #       #      |
+|     E        R   R    R   R    O     O  R   R                               |
+|     E        R    R   R    R   O     O  R    R      ###     ###     ###     |
+|     EEEEEEE  R     R  R     R  OOOOOOO  R     R     ###     ###     ###     |
+|                                                                             |
+|                                                                             |
+ ----------------------------------------------------------------------------- 
+

--- a/tests/test_outcar.py
+++ b/tests/test_outcar.py
@@ -334,3 +334,11 @@ def test_run_status(outcar_parser, expected):
     assert run_status['electronic_converged'] is expected[2]
     assert run_status['consistent_nelm_breach'] is expected[3]
     assert run_status['contains_nelm_breach'] is expected[4]
+
+
+def test_crashed_outcar(outcar_parser):
+    """Test incomplete OUTCAR"""
+    testdir = os.path.dirname(__file__)
+    outcarfile = os.path.join(testdir, 'OUTCAR.crashed')
+    with pytest.raises(SystemExit):
+        outcar = Outcar(file_path=outcarfile)


### PR DESCRIPTION
Fix https://github.com/aiida-vasp/parsevasp/issues/94

When a VASP calculation crashes before starting SCF iterations,
we fail to parse OUTCAR. This commit implements to report an error message
in such a situation.