### PR TITLE
Replaced bands data container names with eigenvalues

### DIFF
--- a/parsevasp/eigenval.py
+++ b/parsevasp/eigenval.py
@@ -44,7 +44,7 @@ class Eigenval(BaseParser):
             sys.exit(self.ERROR_USE_ONE_ARGUMENT)
 
         self._data = {
-            'bands': None,
+            'eigenvalues': None,
             'kpoints': None,
             'metadata': None
         }
@@ -77,7 +77,7 @@ class Eigenval(BaseParser):
 
     def _from_list(self, eigenval):
         """
-        Go through the list and extract bands, kpoints and metadata.
+        Go through the list and extract eigenvalues, kpoints and metadata.
 
         Parameters
         ----------
@@ -110,7 +110,7 @@ class Eigenval(BaseParser):
         data = re.split(utils.empty_line, data)
         data = [[line.split() for line in block.splitlines()] for block in data]
         kpoints = np.zeros((num_kp, 4))
-        bands = np.zeros((num_spins, num_kp, num_bands))
+        eigenvalues = np.zeros((num_spins, num_kp, num_bands))
         # Iterate over blocks, pr. k-point
         for k, field in enumerate(data):
             # Remove empty lines
@@ -120,7 +120,7 @@ class Eigenval(BaseParser):
             kpoints[k] = kpi
             # The rest is the band energies
             for point in kpbs:
-                bands[:, k, int(point[0]) - 1] = point[1:num_spins + 1]
+                eigenvalues[:, k, int(point[0]) - 1] = point[1:num_spins + 1]
 
         # Create the metadata dict
         metadata = {}
@@ -139,7 +139,7 @@ class Eigenval(BaseParser):
 
         # Store
         self._data['metadata'] = metadata
-        self._data['bands'] = bands
+        self._data['eigenvalues'] = eigenvalues
         self._data['kpoints'] = kpoints
 
     def get_metadata(self):
@@ -161,9 +161,9 @@ class Eigenval(BaseParser):
         metadata = self._data['metadata']
         return metadata
 
-    def get_bands(self):
+    def get_eigenvalues(self):
         """
-        Return the bands.
+        Return the eigenvalues.
 
         Parameters
         ----------
@@ -172,13 +172,13 @@ class Eigenval(BaseParser):
         Returns
         -------
         elastic : nparray
-            A numpy array containing the bands. First index is spin, second k-points and the last,
+            A numpy array containing the eigenvalues. First index is spin, second k-points and the last,
             the band index.
 
         """
 
-        bands = self._data['bands']
-        return bands
+        eigenvalues = self._data['eigenvalues']
+        return eigenvalues
 
     def get_kpoints(self):
         """

--- a/tests/test_eigenval.py
+++ b/tests/test_eigenval.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 from parsevasp.eigenval import Eigenval
 
-compare_bands = np.array([[[-1.439825, 2.964373, 2.964373, 2.964373, 7.254542, 7.254542, 7.254542, 11.451811, 11.670398, 11.670398]]])
+compare_eigenvalues = np.array([[[-1.439825, 2.964373, 2.964373, 2.964373, 7.254542, 7.254542, 7.254542, 11.451811, 11.670398, 11.670398]]])
 compare_kpoints = np.array([[0.25, 0.25, 0.25, 1.0]])
 compare_metadata = {0: [4, 4, 1, 1], 1: [16.48482, 4.04e-10, 4.04e-10, 4.04e-10, 1e-16], 2: 0.0001, 'n_ions': 4, 'n_atoms': 4, 'p00': 1, 'nspin': 1, 'cartesian': True, 'name': 'unknown system', 'some_num': 12, 'n_bands': 10, 'n_kp': 1}
 
@@ -42,10 +42,10 @@ def eigenval_parser_file_object(request):
     return eigenval
 
 def test_eigenval(eigenval_parser):
-    """Test that the content returned by the EIGENVAL parser returns correct bands, kpoints and metadata."""
-    bands = eigenval_parser.get_bands()
+    """Test that the content returned by the EIGENVAL parser returns correct eigenvalues, kpoints and metadata."""
+    eigenvalues = eigenval_parser.get_eigenvalues()
     kpoints = eigenval_parser.get_kpoints()
     metadata = eigenval_parser.get_metadata()
-    assert np.allclose(bands, compare_bands)
+    assert np.allclose(eigenvalues, compare_eigenvalues)
     assert np.allclose(kpoints, compare_kpoints)
     assert metadata == compare_metadata


### PR DESCRIPTION
We replace the `bands` terminology unless we explicitly describe the concatenation of eigenvalues across several k-points, e.g. `num_bands` as `num_eigenvalues` would potentially be a bit misleading as it typically can also run over several k-points. Hence, some of the bands terminology is kept, but not for the data containers themselves.