### PR TITLE
Fix logging

### DIFF
--- a/parsevasp/base.py
+++ b/parsevasp/base.py
@@ -46,8 +46,20 @@ class BaseParser(ABC):  # pylint: disable=R0903
         if logger is not None:
             self._logger = logger
         else:
-            logging.basicConfig(level=logging.DEBUG)
-            self._logger = logging.getLogger('ParsevaspParser')
+            self._logger = self._setup_logger(logging.DEBUG)
+
+    def _setup_logger(self, level):
+        """Setup a logger for this class"""
+        logger = logging.getLogger(str(self.__class__))
+        logger.setLevel(level)
+        if not logger.handlers:
+            handler = logging.StreamHandler()
+            handler.setLevel(level)
+            formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+            handler.setFormatter(formatter)
+            logger.addHandler(handler)
+        return logger
+
 
     def write(self, **kwargs):
         """Write respective content as files using a path or handler.

--- a/parsevasp/base.py
+++ b/parsevasp/base.py
@@ -50,7 +50,7 @@ class BaseParser(ABC):  # pylint: disable=R0903
 
     def _setup_logger(self, level):
         """Setup a logger for this class"""
-        logger = logging.getLogger(str(self.__class__))
+        logger = logging.getLogger(self.__module__ + '.' + self.__class__.__name__)
         logger.setLevel(level)
         if not logger.handlers:
             handler = logging.StreamHandler()

--- a/tests/test_poscar.py
+++ b/tests/test_poscar.py
@@ -1,11 +1,8 @@
 """Test poscar."""
 import os
-import logging
-from turtle import pos
 
 import numpy as np
 import pytest
-from parsevasp import poscar
 
 from parsevasp.poscar import Poscar, Site
 

--- a/tests/test_poscar.py
+++ b/tests/test_poscar.py
@@ -1,8 +1,11 @@
 """Test poscar."""
 import os
+import logging
+from turtle import pos
 
 import numpy as np
 import pytest
+from parsevasp import poscar
 
 from parsevasp.poscar import Poscar, Site
 
@@ -59,6 +62,13 @@ def poscar_parser_vel():
     poscar = Poscar(file_path=poscarfile)
 
     return poscar
+
+
+@pytest.mark.parametrize('poscar_parser', [(True,)], indirect=True)
+def test_poscar_log(poscar_parser):
+    """Test the logger"""
+    assert poscar_parser._logger.name == 'parsevasp.poscar.Poscar'
+    assert len(poscar_parser._logger.handlers) == 1
 
 
 @pytest.mark.parametrize('poscar_parser', [(True,)], indirect=True)


### PR DESCRIPTION
Fix the logger that previously changes the global setting. 

Each class now gets its own logger. Should now behave like this:

```python
In [10]: p = Poscar(file_path="tmp/POSCAR")

In [11]: p._logger.debug("Foo")
2022-02-09 10:26:02,840 - parsevasp.poscar.Poscar - DEBUG - Foo
```

