### PR TITLE
Update incar.py

### DIFF
--- a/parsevasp/incar.py
+++ b/parsevasp/incar.py
@@ -542,7 +542,7 @@ class IncarItem:
 
         # Make sure we keep compatibility between Python 2 and 3
         if isinstance(value, basestring):
-            if clean_tag in ('system', 'magmom'):
+            if clean_tag in ('system', 'magmom', 'm_constr'):
                 # If value is SYSTEM or MAGMOM (can contain asterix), treat it a bit special and
                 # leave its string intact but remove grub
                 clean_value = value.strip()


### PR DESCRIPTION
Bypass checking for same types inside a INCAR entry for `m_constr`. This tag supports the same syntex as `MAGMOM`. 

Fixes: https://github.com/aiida-vasp/aiida-vasp/issues/626