### PR TITLE
Tentative fix to run pre-commit via tox on python 3.10 venv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Tox
         run: pip install tox
       - name: Run pre-commit in Tox
-        run: tox -e pre-commit
+        run: tox -e py310-pre-commit
   tests:
     needs: [pre-commit]
     runs-on: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pre-commit,{py37,py38,py39,py310}-parsevasp
+envlist = py310-pre-commit,{py37,py38,py39,py310}-parsevasp
 requires = virtualenv >= 20
 
 [testenv]
@@ -8,7 +8,7 @@ commands =
 
 extras = tests
 
-[testenv:pre-commit]
+[testenv:py310-pre-commit]
 allowlist_externals = bash
 commands = bash -ec 'pre-commit run --all-files || ( git diff; git status; exit 1; )'
 extras =


### PR DESCRIPTION
This is a tentative fix to run pre-commit via tox on python 3.10 venv on python 3.11 host. I need this PR to be merged because #123, however we should have many options about how to solve this issue, so I consider that this PR is a tentative fix.

After this PR, to run only pre-commit,
```
tox -e py310-pre-commit
```
rather than
```
tox -e pre-commit
```
