### PR TITLE
125 potcar metada is not parsed

### DIFF
--- a/parsevasp/potcar.py
+++ b/parsevasp/potcar.py
@@ -1,0 +1,73 @@
+"""Handle POTCAR"""
+
+import re
+
+from parsevasp import utils
+from parsevasp.base import BaseParser
+
+
+class Potcar(BaseParser):
+
+    def __init__(self, file_path=None, file_handler=None, logger=None):
+        super().__init__(file_path, file_handler, logger)
+
+    if self._file_path is not None or self._file_handler is not None:
+        self.metadata = self._from_file()
+
+
+
+    def _from_file(self):
+        """Create rudimentary dictionary of entries from a
+        file.
+
+        """
+
+        potcar = utils.read_from_file(self._file_path, self._file_handler, encoding='utf8')
+
+        return self._generate_metadata(potcar)
+
+    def _generate_metadata(potcar_contents:str) -> dict:
+        _parameters_to_parse = {
+            'VRHFIN': str,
+            'LEXCH': str,
+            'EATOM': float,
+            'TITEL': str,
+            'LULTRA': bool,
+            'IUNSCR': int,
+            'RPACOR': float,
+            'POMASS': float, 'ZVAL': float,
+            'RCORE': float,
+            'RWIGS': float,
+            'ENMAX': float, 'ENMIN': float,
+            'RCLOC': float,
+            'LCOR': bool,
+            'LPAW': bool,
+            'EAUG': float,
+            'DEXC': float,
+            'RMAX': float,
+            'RAUG': float,
+            'RDEP': float,
+            'RDEPT': float,
+            'NDATA': int,
+            'STEP': list,
+        }
+        search_lines = re.search(
+            r"(?s)(parameters from PSCTR are:"
+            r".*?END of PSCTR-controll parameters)",
+            potcar_contents,
+        ).group(1)
+
+        metadata = {}
+        for key, val in re.findall(r"(\S+)\s*=\s*(.*?)(?=;|$)", search_lines, flags=re.MULTILINE):
+            if key in _parameters_to_parse:
+                if isinstance(_parameters_to_parse[key], str):
+                    metadata[key] = val.split()
+                if isinstance(_parameters_to_parse, int):
+                    metadata[key] = int(re.match(r"^-?[0-9]+", val).group(0))
+                if isinstance(_parameters_to_parse[key], float):
+                    metadata[key] = float(re.search(r"^-?\d*\.?\d*[eE]?-?\d*", val).group(0))
+                if isinstance(_parameters_to_parse[key], bool):
+                    metadata[key] = re.match(r"^\.?([TFtf])[A-Za-z]*\.?", val).group(1).lower() in ['t']
+                if isinstance(_parameters_to_parse[key], list):
+                    metadata[key] = [float(y) for y in re.split(r"\s+", val.strip()) if not y.isalpha()]
+        return metadata

--- a/parsevasp/potcar.py
+++ b/parsevasp/potcar.py
@@ -104,6 +104,7 @@ class Potcar(BaseParser):
             'LPAW': lambda val: re.match(r'^\.?([TFtf])[A-Za-z]*\.?', val).group(1).lower() in ['t'],
             'IUNSCR': lambda val: int(re.match(r'^-?[0-9]+', val).group(0)),
             'NDATA': lambda val: int(re.match(r'^-?[0-9]+', val).group(0)),
+            'ICORE': lambda val: int(re.match(r'^-?[0-9]+', val).group(0)),
             'EATOM': lambda val: float(re.search(r'^-?\d*\.?\d*[eE]?-?\d*', val).group(0)),
             'RPACOR': lambda val: float(re.search(r'^-?\d*\.?\d*[eE]?-?\d*', val).group(0)),
             'POMASS': lambda val: float(re.search(r'^-?\d*\.?\d*[eE]?-?\d*', val).group(0)),

--- a/parsevasp/potcar.py
+++ b/parsevasp/potcar.py
@@ -1,4 +1,8 @@
-"""Handle POTCAR"""
+"""Handle POTCAR
+
+This parser takes parts of the
+`pymatgen parser<https://github.com/materialsproject/pymatgen/blob/v2023.3.23/pymatgen/io/vasp/inputs.py#L1616-L2211>`_
+"""
 
 import re
 
@@ -7,14 +11,66 @@ from parsevasp.base import BaseParser
 
 
 class Potcar(BaseParser):
+    """Class to handle the POTCAR"""
+
+    _functional_tags = {
+        'pe': {
+            'name': 'PBE',
+            'class': 'GGA'
+        },
+        '91': {
+            'name': 'PW91',
+            'class': 'GGA'
+        },
+        'rp': {
+            'name': 'revPBE',
+            'class': 'GGA'
+        },
+        'am': {
+            'name': 'AM05',
+            'class': 'GGA'
+        },
+        'ps': {
+            'name': 'PBEsol',
+            'class': 'GGA'
+        },
+        'pw': {
+            'name': 'PW86',
+            'class': 'GGA'
+        },
+        'lm': {
+            'name': 'Langreth-Mehl-Hu',
+            'class': 'GGA'
+        },
+        'pb': {
+            'name': 'Perdew-Becke',
+            'class': 'GGA'
+        },
+        'ca': {
+            'name': 'Perdew-Zunger81',
+            'class': 'LDA'
+        },
+        'hl': {
+            'name': 'Hedin-Lundquist',
+            'class': 'LDA'
+        },
+        'wi': {
+            'name': 'Wigner Interpoloation',
+            'class': 'LDA'
+        },
+    }
 
     def __init__(self, file_path=None, file_handler=None, logger=None):
-        super().__init__(file_path, file_handler, logger)
+        super().__init__(file_path=file_path, file_handler=file_handler, logger=logger)
 
-    if self._file_path is not None or self._file_handler is not None:
-        self.metadata = self._from_file()
+        self.metadata = None
+        self._symbol = None
+        self._element = None
 
-
+        if self._file_path is not None or self._file_handler is not None:
+            self._from_file()
+        if self._file_path is None and self._file_handler is None:
+            raise ValueError('Either "file_path" or "file_handler" should be passed')
 
     def _from_file(self):
         """Create rudimentary dictionary of entries from a
@@ -22,52 +78,126 @@ class Potcar(BaseParser):
 
         """
 
-        potcar = utils.read_from_file(self._file_path, self._file_handler, encoding='utf8')
+        potcar = utils.read_from_file(self._file_path, self._file_handler, encoding='utf8', lines=False)
 
         return self._generate_metadata(potcar)
 
-    def _generate_metadata(potcar_contents:str) -> dict:
+    def _generate_metadata(self, potcar_contents: str):
+        """Get the metadata from a POTCAR file
+
+        Parameters
+        ----------
+        potcar_contents: string
+            The contents of the POTCAR file as a string
+
+        Returns
+        -------
+        metadata: dictionary
+            A dictionary containing the metadata associated with the POTCAR
+        """
         _parameters_to_parse = {
-            'VRHFIN': str,
-            'LEXCH': str,
-            'EATOM': float,
-            'TITEL': str,
-            'LULTRA': bool,
-            'IUNSCR': int,
-            'RPACOR': float,
-            'POMASS': float, 'ZVAL': float,
-            'RCORE': float,
-            'RWIGS': float,
-            'ENMAX': float, 'ENMIN': float,
-            'RCLOC': float,
-            'LCOR': bool,
-            'LPAW': bool,
-            'EAUG': float,
-            'DEXC': float,
-            'RMAX': float,
-            'RAUG': float,
-            'RDEP': float,
-            'RDEPT': float,
-            'NDATA': int,
-            'STEP': list,
+            'VRHFIN': lambda val: val.strip(),
+            'LEXCH': lambda val: val.strip(),
+            'TITEL': lambda val: val.strip(),
+            'LULTRA': lambda val: re.match(r'^\.?([TFtf])[A-Za-z]*\.?', val).group(1).lower() in ['t'],
+            'LCOR': lambda val: re.match(r'^\.?([TFtf])[A-Za-z]*\.?', val).group(1).lower() in ['t'],
+            'LPAW': lambda val: re.match(r'^\.?([TFtf])[A-Za-z]*\.?', val).group(1).lower() in ['t'],
+            'IUNSCR': lambda val: int(re.match(r'^-?[0-9]+', val).group(0)),
+            'NDATA': lambda val: int(re.match(r'^-?[0-9]+', val).group(0)),
+            'EATOM': lambda val: float(re.search(r'^-?\d*\.?\d*[eE]?-?\d*', val).group(0)),
+            'RPACOR': lambda val: float(re.search(r'^-?\d*\.?\d*[eE]?-?\d*', val).group(0)),
+            'POMASS': lambda val: float(re.search(r'^-?\d*\.?\d*[eE]?-?\d*', val).group(0)),
+            'ZVAL': lambda val: float(re.search(r'^-?\d*\.?\d*[eE]?-?\d*', val).group(0)),
+            'RCORE': lambda val: float(re.search(r'^-?\d*\.?\d*[eE]?-?\d*', val).group(0)),
+            'RWIGS': lambda val: float(re.search(r'^-?\d*\.?\d*[eE]?-?\d*', val).group(0)),
+            'ENMAX': lambda val: float(re.search(r'^-?\d*\.?\d*[eE]?-?\d*', val).group(0)),
+            'ENMIN': lambda val: float(re.search(r'^-?\d*\.?\d*[eE]?-?\d*', val).group(0)),
+            'RCLOC': lambda val: float(re.search(r'^-?\d*\.?\d*[eE]?-?\d*', val).group(0)),
+            'EAUG': lambda val: float(re.search(r'^-?\d*\.?\d*[eE]?-?\d*', val).group(0)),
+            'DEXC': lambda val: float(re.search(r'^-?\d*\.?\d*[eE]?-?\d*', val).group(0)),
+            'RMAX': lambda val: float(re.search(r'^-?\d*\.?\d*[eE]?-?\d*', val).group(0)),
+            'RAUG': lambda val: float(re.search(r'^-?\d*\.?\d*[eE]?-?\d*', val).group(0)),
+            'RDEP': lambda val: float(re.search(r'^-?\d*\.?\d*[eE]?-?\d*', val).group(0)),
+            'RDEPT': lambda val: float(re.search(r'^-?\d*\.?\d*[eE]?-?\d*', val).group(0)),
+            'STEP': lambda val: [float(y) for y in re.split(r'\s+', val.strip()) if not y.isalpha()],
         }
         search_lines = re.search(
-            r"(?s)(parameters from PSCTR are:"
-            r".*?END of PSCTR-controll parameters)",
+            r'(?s)(parameters from PSCTR are:'
+            r'.*?END of PSCTR-controll parameters)',
             potcar_contents,
         ).group(1)
 
-        metadata = {}
-        for key, val in re.findall(r"(\S+)\s*=\s*(.*?)(?=;|$)", search_lines, flags=re.MULTILINE):
+        self.metadata = {}
+        for key, val in re.findall(r'(\S+)\s*=\s*(.*?)(?=;|$)', search_lines, flags=re.MULTILINE):
             if key in _parameters_to_parse:
-                if isinstance(_parameters_to_parse[key], str):
-                    metadata[key] = val.split()
-                if isinstance(_parameters_to_parse, int):
-                    metadata[key] = int(re.match(r"^-?[0-9]+", val).group(0))
-                if isinstance(_parameters_to_parse[key], float):
-                    metadata[key] = float(re.search(r"^-?\d*\.?\d*[eE]?-?\d*", val).group(0))
-                if isinstance(_parameters_to_parse[key], bool):
-                    metadata[key] = re.match(r"^\.?([TFtf])[A-Za-z]*\.?", val).group(1).lower() in ['t']
-                if isinstance(_parameters_to_parse[key], list):
-                    metadata[key] = [float(y) for y in re.split(r"\s+", val.strip()) if not y.isalpha()]
-        return metadata
+                self.metadata[key] = _parameters_to_parse[key](val)
+
+        try:
+            self._symbol = self.metadata['TITEL'].split(' ')[1].strip()
+        except IndexError:
+            self._symbol = self.metadata['TITEL'].strip()
+
+        self._element = self._symbol.split('_')[0]
+
+    @property
+    def symbol(self):
+        """
+        Get the symbol associated with this POTCAR
+
+        Returns
+        -------
+        symbol: string
+            The POTCAR symbol, e.g. W_pv
+        """
+        return self._symbol
+
+    @property
+    def element(self):
+        """
+        Get the symbol of the element associated with this POTCAR
+
+        Returns
+        -------
+        element: string
+            The POTCAR element, e.g. W
+        """
+        return self._element
+
+    @property
+    def functional(self):
+        """
+        Get the functional associated with this POTCAR
+
+        Returns
+        -------
+        functional: string
+            Functional associated with the current POTCAR file.
+        """
+        return self._functional_tags.get(self.metadata.get('LEXCH').lower(), {}).get('name')
+
+    @property
+    def functional_class(self):
+        """
+        Get the functional class associated with this POTCAR
+
+        Returns
+        --------
+        functional_class: string
+            Functional class associated with the current POTCAR file.
+        """
+        return self._functional_tags.get(self.metadata.get('LEXCH').lower(), {}).get('class')
+
+    def __getattr__(self, attribute):
+        """
+        Delegates attributes to keywords. For example, you can use
+        potcar.enmax to get the ENMAX of the POTCAR.
+        For float type properties, they are converted to the correct float. By
+        default, all energies in eV and all length scales are in Angstroms.
+        """
+        try:
+            return self.metadata[attribute.upper()]
+        except Exception as exc:
+            raise AttributeError(attribute) from exc
+
+    def _write(self, file_handler, **kwargs):
+        return super()._write(file_handler, **kwargs)  #pylint: disable=useless-super-delegation

--- a/parsevasp/potcar.py
+++ b/parsevasp/potcar.py
@@ -200,4 +200,4 @@ class Potcar(BaseParser):
             raise AttributeError(attribute) from exc
 
     def _write(self, file_handler, **kwargs):
-        return super()._write(file_handler, **kwargs)  #pylint: disable=useless-super-delegation
+        pass

--- a/tests/POTCAR
+++ b/tests/POTCAR
@@ -1,0 +1,67 @@
+  PAW In_sv 11Feb1111
+   11.1111111111111
+ parameters from PSCTR are:
+   VRHFIN =In: s1p1
+   LEXCH  = CA
+   EATOM  =  1111.1111 eV,  111.1111 Ry
+
+   TITEL  = PAW In_d 11Feb1111
+   LULTRA =        F    use ultrasoft PP ?
+   IUNSCR =        1    unscreen: 1-lin 1-nonlin 1-no
+   RPACOR =    1.111    partial core radius
+   POMASS =  111.111; ZVAL   =   11.111    mass and valenz
+   RCORE  =    1.111    outmost cutoff radius
+   RWIGS  =    1.111; RWIGS  =    1.111    wigner-seitz radius (au A)
+   ENMAX  =  111.111; ENMIN  =  111.111 eV
+   ICORE  =        1    local potential
+   LCOR   =        T    correct aug charges
+   LPAW   =        T    paw PP
+   EAUG   =  111.111
+   DEXC   =    1.111
+   RMAX   =    1.111    core radius for proj-oper
+   RAUG   =    1.111    factor for augmentation sphere
+   RDEP   =    1.111    radius for radial grids
+   RDEPT  =    1.111    core radius for aug-charge
+
+   Atomic configuration
+   11 entries
+     n  l   j            E        occ.
+     1  1   1.1        1.1     1.1
+     1  1   1.1        1.1     1.1
+     1  1   1.1        1.1     1.1
+     1  1   1.1        1.1     1.1
+     1  1   1.1        1.1     1.1
+     1  1   1.1        1.1     1.1
+     1  1   1.1        1.1     1.1
+     1  1   1.1        1.1     1.1
+     1  1   1.1        1.1     1.1
+     1  1   1.1        1.1     1.1
+    Description
+     l       E           TYP  RCUT    TYP  RCUT
+     1      1.1          11  1.1
+     1      1.1          11  1.1
+     1      1.1          11  1.1
+     1      1.1          11  1.1
+     1      1.1          11  1.1
+     1      1.1          11  1.1
+   Error from kinetic energy argument (eV)
+   NDATA  =      111
+   STEP   =   11.1   1.1
+  11.1      11.1      11.1      11.1      11.1      11.1      11.1      11.1
+  11.1      11.1      11.1      11.1      11.1      1.1      1.1      1.1
+  1.1      1.1      1.1      1.1      1.1      1.1      1.1      1.1
+  1.1      1.1      1.1      1.1      1.1      1.1     1.1     1.1
+ 1.1     1.1     1.1     1.1     1.1     1.1     1.1     1.1
+ 1.1     1.1 1.1 1.1 1.1 1.1 1.1 1.1
+ 1.1 1.1 1.1 1.1 1.1 1.1 1.1 1.1
+ 1.1 1.1 1.1 1.1 1.1 1.1 1.1 1.1
+ 1.1 1.1 1.1 1.1 1.1 1.1 1.1 1.1
+ 1.1 1.1 1.1 1.1 1.1 1.1 1.1 1.1
+ 1.1 1.1 1.1 1.1 1.1 1.1 1.1 1.1
+ 1.1 1.1 1.1 1.1 1.1 1.1 1.1 1.1
+ 1.1 1.1 1.1 1.1
+END of PSCTR-controll parameters
+
+ ... DATA ...
+
+ End of Dataset

--- a/tests/test_potcar.py
+++ b/tests/test_potcar.py
@@ -1,0 +1,102 @@
+"""Test potcar."""
+import os
+
+import numpy as np
+import pytest
+
+from parsevasp.potcar import Potcar
+
+
+@pytest.fixture(scope='module')
+def potcar_reference_metadata():
+    """Reference metadata for a dummy POTCAR"""
+    metadata = {
+        'VRHFIN': 'In: s1p1',
+        'LEXCH': 'CA',
+        'EATOM': 1111.1111,
+        'TITEL': 'PAW In_d 11Feb1111',
+        'LULTRA': False,
+        'IUNSCR': 1,
+        'RPACOR': 1.111,
+        'POMASS': 111.111,
+        'ZVAL': 11.111,
+        'RCORE': 1.111,
+        'RWIGS': 1.111,
+        'ENMAX': 111.111,
+        'ENMIN': 111.111,
+        'ICORE': 1,
+        'LCOR': True,
+        'LPAW': True,
+        'EAUG': 111.111,
+        'DEXC': 1.111,
+        'RMAX': 1.111,
+        'RAUG': 1.111,
+        'RDEP': 1.111,
+        'RDEPT': 1.111,
+    }
+
+    return metadata
+
+
+@pytest.fixture(scope='module')
+def potcar_parser(request):
+    """Load POTCAR file."""
+
+    testdir = os.path.dirname(__file__)
+    potcarfile = os.path.join(testdir, 'POTCAR')
+    potcar = Potcar(file_path=potcarfile)
+
+    return potcar
+
+
+@pytest.fixture(scope='module')
+def potcar_parser_file_object():
+    """Load POTCAR file using a file object."""
+
+    testdir = os.path.dirname(__file__)
+    potcarfile = os.path.join(testdir, 'POTCAR')
+    potcar = None
+    with open(potcarfile, 'r', encoding='utf8') as file_handler:
+        potcar = Potcar(file_handler=file_handler)
+
+    return potcar
+
+
+@pytest.mark.parametrize(
+    'potcar_object,reference_values', [
+        ('potcar_parser', 'potcar_reference_metadata'),
+        ('potcar_parser_file_object', 'potcar_reference_metadata'),
+    ]
+)
+def test_potcar_metadata(potcar_object, reference_values, request):
+    """Test if the metadata produced matches the expected one"""
+    potcar_object = request.getfixturevalue(potcar_object)
+    reference_values = request.getfixturevalue(reference_values)
+
+    for key, value in reference_values.items():
+        assert key in potcar_object.metadata, f'key "{key}" not in the metadata'
+        assert value == potcar_object.metadata[
+            key
+        ], f'referance value "{value}" does not match to found value {potcar_object.metadata[key]} for key "{key}"'
+
+
+@pytest.mark.parametrize(
+    'potcar_object,reference_values', [
+        ('potcar_parser', 'potcar_reference_metadata'),
+        ('potcar_parser_file_object', 'potcar_reference_metadata'),
+    ]
+)
+def test_potcar_attributes(potcar_object, reference_values, request):
+    """Test if the attributes are correctly setup"""
+    potcar_object = request.getfixturevalue(potcar_object)
+    reference_values = request.getfixturevalue(reference_values)
+
+    extra_values = {'symbol': 'In_d', 'element': 'In', 'functional': 'Perdew-Zunger81', 'functional_class': 'LDA'}
+
+    reference_values.update(extra_values)
+
+    for key, value in reference_values.items():
+        assert hasattr(potcar_object, key.lower()), f'attribute {key} not found in potcar'
+        assert getattr(
+            potcar_object, key.lower()
+        ) == value, f'value of attribute {key} {getattr(potcar_object, key.lower())} does not match reference {value}'


### PR DESCRIPTION
Adding parsing of the metadata of the potential directly to a potcar parser so that we do not have to depend on pymatgen.

Closes #125.