### PR TITLE
Removed future dep and aiida core pylint dep pinning

### DIFF
--- a/parsevasp/incar.py
+++ b/parsevasp/incar.py
@@ -4,8 +4,6 @@ import io
 import logging
 import sys
 
-from past.builtins import basestring
-
 from parsevasp import constants, utils
 from parsevasp.base import BaseParser
 
@@ -241,7 +239,7 @@ class Incar(BaseParser):
 
         return incar_dict
 
-    def _convert_value_to_string(self, value):  # pylint: disable=R0201
+    def _convert_value_to_string(self, value):
         """
         Converts a value for an INCAR entry to a string that
         is compatible with VASP.
@@ -540,8 +538,7 @@ class IncarItem:
         # However, let us also open for the fact that users might
         # give a value what they would in INCAR
 
-        # Make sure we keep compatibility between Python 2 and 3
-        if isinstance(value, basestring):
+        if isinstance(value, str):
             if clean_tag in ('system', 'magmom', 'm_constr'):
                 # If value is SYSTEM or MAGMOM (can contain asterix), treat it a bit special and
                 # leave its string intact but remove grub
@@ -601,7 +598,7 @@ class IncarItem:
 
         return clean_tag, clean_value, clean_comment
 
-    def _test_string_for_bool(self, string):  # pylint: disable=R0201
+    def _test_string_for_bool(self, string):
         """
         Detects if string contains Fortran bool.
 

--- a/parsevasp/kpoints.py
+++ b/parsevasp/kpoints.py
@@ -773,11 +773,11 @@ class Kpoints(BaseParser):
         self._check_tetra()
         self._check_tetra_volume()
 
-    def _to_direct(self, point):  # pylint: disable=R0201
+    def _to_direct(self, point):
 
         return point
 
-    def _to_cart(self, point):  # pylint: disable=R0201
+    def _to_cart(self, point):
 
         return point
 

--- a/parsevasp/poscar.py
+++ b/parsevasp/poscar.py
@@ -223,8 +223,8 @@ class Poscar(BaseParser):
             unitcell = scaling * unitcell
             spec = poscar[5].split()
             atoms = [int(x) for x in poscar[6].split()]
-            for i, _ in enumerate(atoms):
-                nions = nions + atoms[i]
+            for num_ions in atoms:
+                nions = nions + num_ions
             if poscar[7][0].lower() == 's':
                 selective = True
                 loopmax = 9
@@ -678,12 +678,12 @@ class Poscar(BaseParser):
                 num_species.append(1)
         return sites, species_concat, num_species, selective, velocities, predictors
 
-    def _get_key(self, item):  # pylint: disable=R0201
+    def _get_key(self, item):
         """Key fetcher for the sorted function."""
 
         return item[0]
 
-    def _to_direct(self, position_cart, unitcell):  # pylint: disable=R0201
+    def _to_direct(self, position_cart, unitcell):
         """
         Transforms the position from cartesian to direct
         coordinates.
@@ -710,7 +710,7 @@ class Poscar(BaseParser):
 
         return position
 
-    def _to_cart(self, position_dir, unitcell):  # pylint: disable=R0201
+    def _to_cart(self, position_dir, unitcell):
         """
         Transforms the position from direct to cartesian
         coordinates.

--- a/parsevasp/stream.py
+++ b/parsevasp/stream.py
@@ -122,7 +122,7 @@ class Stream(BaseParser):  # pylint: disable=R0902
 
         return stream_config
 
-    def _load_config_from_file(self):  # pylint: disable=R0201
+    def _load_config_from_file(self):
         """Read the configuration of the errors and warnings from a yaml file and save it as the class method."""
 
         stream_config = None

--- a/parsevasp/vasprun.py
+++ b/parsevasp/vasprun.py
@@ -3214,7 +3214,7 @@ class Xml(BaseParser):  #  pylint: disable=R0902, R0904
 
         # Check if the supplied etype is in the support list
         for item in etype:
-            if item not in _SUPPORTED_TOTAL_ENERGIES.keys():
+            if item not in _SUPPORTED_TOTAL_ENERGIES.keys():  # pylint: disable=consider-iterating-dictionary
                 raise ValueError(f'The supplied total energy type: {item} is not supported.')
 
         return self._get_energies(status, etype, nosc)
@@ -3554,7 +3554,7 @@ class Xml(BaseParser):  #  pylint: disable=R0902, R0904
             )
             sys.exit(self.ERROR_UNSUPPORTED_STATUS)
 
-    def _find(self, xml, locator):  # pylint: disable=R0201
+    def _find(self, xml, locator):
         """Wrapper to check if the request returns something.
 
         Parameters
@@ -3578,7 +3578,7 @@ class Xml(BaseParser):  #  pylint: disable=R0902, R0904
             return None
         return entry
 
-    def _findall(self, xml, locator):  # pylint: disable=R0201
+    def _findall(self, xml, locator):
         """Wrapper to check if the request returns something.
 
         Parameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ requires-python = ">=3.7"
 dependencies = [
         "numpy",
         "lxml",
-	"future",
         "pyyaml"
 ]
 
@@ -51,7 +50,7 @@ pre-commit = [
 	   "tox>=3.23.0",
 	   "virtualenv>20",
 	   "pre-commit~=2.2",
-	   "pylint~=2.11.1"
+	   "pylint~=2.15.0"
 ]
 
 [tool.flit.module]
@@ -84,7 +83,6 @@ indent_dictionary_value = false
 
 [tool.pylint.messages_control]
 disable = [
-    'bad-continuation',
     'duplicate-code',
     'locally-disabled',
     'logging-format-interpolation',


### PR DESCRIPTION
Here we remove our usage of `past` and thus the `future` dependency. In addition, we had to address #123 to fix linting runs on Python 3.11. This also triggered various other updates to the linting.

Closes #123, #126.