### PR TITLE
V3.2.1 into develop

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1] - 2023-06-29
+
+### Changed
+- More docstring about the code from `pymatgen` code for the `POTCAR` metadata parser.
+- Changed from `node` 12 to 16 for the Github Actions.
+
 ## [3.2.0] - 2023-06-05
 
 ### Added

--- a/parsevasp/__init__.py
+++ b/parsevasp/__init__.py
@@ -1,6 +1,6 @@
 """A parser for VASP."""
 
-__version__ = '3.2.0'
+__version__ = '3.2.1'
 
 import parsevasp.incar
 import parsevasp.kpoints


### PR DESCRIPTION
Merging `master` back into `develop` after `v3.2.1` release.