### PR TITLE
Updating INCAR parameter parsing

### DIFF
--- a/parsevasp/vasprun.py
+++ b/parsevasp/vasprun.py
@@ -376,7 +376,7 @@ class Xml(BaseParser):
                         self._version = element.text
                 except KeyError:
                     pass
-            if extract_parameters and event == 'start':
+            if extract_parameters and event == 'end':
                 if element.tag in ['i', 'v']:
                     name, param_value = self._convert_parameter(element)
                     if self._parameters[name] is not None:


### PR DESCRIPTION
I recently discovered that the INCAR parameter parsing would not give the associated value from the vasprun.xml file if it was a long string broken up over multiple longs. This is because at the `start` event that is being checked, it had not finished finding all the text. Changing the one line to `event == 'end'` fixes this issue.