### PR TITLE
Bump version to 3.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
       - name: Install parsevasp
         run: pip install -e . -vvv
       - name: Run pytest
+        env:
+          COVERAGE_CORE: ${{ matrix.python >= '3.12' && 'sysmon' || '' }}
         run: pytest --cov=./ --cov-report=xml tests
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/parsevasp/__init__.py
+++ b/parsevasp/__init__.py
@@ -1,6 +1,6 @@
 """A parser for VASP."""
 
-__version__ = '3.3.0'
+__version__ = '3.4.0'
 
 # import parsevasp.incar
 # import parsevasp.kpoints


### PR DESCRIPTION
Bump the version number to 3.4.0. After this we should make a new release. 
This is needed for releasing a new version of `aiida-vasp`. 